### PR TITLE
Remove nptyping and add python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         runs-on: [ubuntu-latest, macos-14]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "rasterio",
   "numba",
   "tqdm",
-  "nptyping",
   "lazy-loader"
   ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]

--- a/src/scrollstats/delineation/array_types.py
+++ b/src/scrollstats/delineation/array_types.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
-from nptyping import Bool, Float, NDArray, Shape
+from numpy import ndarray
 
 # Define array types
+# nptyping module was originally used to define numpy array types, but is incompatible with numpy v2.0 so it was removed
+# Defined array types were preserved with generic `ndarray` to communicate returned array dtypes in type hints
 
 ## Array2D: 2D array of any size of any dtype
-Array2D: TypeAlias = NDArray[Shape["*, *"], Any]  # noqa: F722  pylint: disable=C0103
+Array2D: TypeAlias = ndarray  # pylint: disable=C0103
 
 ## ElevationArray2D: 2D array of any size of dtype float
-ElevationArray2D: TypeAlias = NDArray[Shape["*, *"], Float]  # noqa: F722  pylint: disable=C0103
+ElevationArray2D: TypeAlias = ndarray  # pylint: disable=C0103
 
 ## BinaryArray2D: 2D array of any size of dtype bool
-BinaryArray2D: TypeAlias = NDArray[Shape["*, *"], Bool]  # noqa: F722  pylint: disable=C0103
+BinaryArray2D: TypeAlias = ndarray  # pylint: disable=C0103
 
 # Define functions as interfaces
 ## `BinaryClassifierFn`s and `BinaryDenoiserFn`s use the following signature:


### PR DESCRIPTION
As seen in #40, `nptyping` is causing an import error with `numpy` 2.0+ when it tries to import the numpy.bool8 datatype that no longer exists.

nptyping has been removed as a dependency and defined any array types now just use numpy.ndarray.

This issue was found with python 3.14 which was not included in CI. CI now includes tests on 3.13 and 3.14.